### PR TITLE
#1 - mu: ditch append

### DIFF
--- a/src/mu/core/backquote.rs
+++ b/src/mu/core/backquote.rs
@@ -24,12 +24,22 @@ use crate::{
 };
 
 pub trait Reader {
+    fn bq_append(_: &Mu, _: Tag) -> exception::Result<Tag>;
     fn bq_read(_: &Mu, _: Tag, _: bool) -> exception::Result<Tag>;
     fn bq_comma(_: &Mu, _: Tag) -> exception::Result<Tag>;
     fn bq_cons(_: &Mu, _: Tag) -> exception::Result<Tag>;
 }
 
 impl Reader for Mu {
+    // backquote append:
+    //
+    //      return Ok(tag) for successful expansion
+    //      return Err exception for stream I/O error or unexpected eof
+    //
+    fn bq_append(_mu: &Mu, _list: Tag) -> exception::Result<Tag> {
+        Ok(Tag::nil())
+    }
+
     // backquote comma:
     //
     //      return Ok(tag) for successful expansion

--- a/src/mu/core/libfunctions.rs
+++ b/src/mu/core/libfunctions.rs
@@ -39,7 +39,6 @@ lazy_static! {
         ("eq", Scope::Extern, 2, Tag::mu_eq),
         ("type-of", Scope::Extern, 1, Tag::mu_typeof),
         // conses and lists
-        ("append", Scope::Extern, 2, Cons::mu_append),
         ("car", Scope::Extern, 1, Cons::mu_car),
         ("cdr", Scope::Extern, 1, Cons::mu_cdr),
         ("cons", Scope::Extern, 2, Cons::mu_cons),

--- a/src/mu/types/cons.rs
+++ b/src/mu/types/cons.rs
@@ -275,7 +275,6 @@ impl Core for Cons {
 
 /// mu functions
 pub trait MuFunction {
-    fn mu_append(_: &Mu, _: &mut Frame) -> exception::Result<()>;
     fn mu_car(_: &Mu, _: &mut Frame) -> exception::Result<()>;
     fn mu_cdr(_: &Mu, _: &mut Frame) -> exception::Result<()>;
     fn mu_cons(_: &Mu, _: &mut Frame) -> exception::Result<()>;
@@ -285,12 +284,6 @@ pub trait MuFunction {
 }
 
 impl MuFunction for Cons {
-    fn mu_append(mu: &Mu, fp: &mut Frame) -> exception::Result<()> {
-        fp.value = Self::append(mu, fp.argv[0], fp.argv[1]);
-
-        Ok(())
-    }
-
     fn mu_car(mu: &Mu, fp: &mut Frame) -> exception::Result<()> {
         let list = fp.argv[0];
 

--- a/tests/mu/list
+++ b/tests/mu/list
@@ -1,7 +1,3 @@
-assert_eq "(mu:append '(1) '(2))" "(1 2)"
-assert_eq "(mu:append '(1) ())" "(1)"
-assert_eq "(mu:append () '(1))" "(1)"
-assert_eq "(mu:append () ())" ":nil"
 assert_eq "(mu:car '(1))" "1"
 assert_eq "(mu:car ())" ":nil"
 assert_eq "(mu:cdr '(1 2))" "(2)"

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -4,7 +4,7 @@ mu:        backquote      total: 6        failed: 0        aborted: 0
 mu:        compile        total: 8        failed: 0        aborted: 0       
 mu:        core           total: 36       failed: 0        aborted: 0       
 mu:        exception      total: 4        failed: 0        aborted: 0       
-mu:        list           total: 26       failed: 0        aborted: 0       
+mu:        list           total: 22       failed: 0        aborted: 0       
 mu:        namespace      total: 16       failed: 0        aborted: 0       
 mu:        number         total: 34       failed: 0        aborted: 0       
 mu:        reader         total: 43       failed: 0        aborted: 0       
@@ -14,7 +14,7 @@ mu:        struct         total: 7        failed: 0        aborted: 0
 mu:        symbol         total: 10       failed: 0        aborted: 0       
 mu:        vector         total: 23       failed: 0        aborted: 0       
 -----------------------
-mu:        passed: 235    total: 235      failed: 0        aborted: 0         
+mu:        passed: 231    total: 231      failed: 0        aborted: 0         
 
 core:      closure        total: 8        failed: 7        aborted: 0       
 core:      compile        total: 24       failed: 0        aborted: 0       


### PR DESCRIPTION
remove unreferenced mu append function

docs: no change
tests: remove mu append tests
perf:  no change
src: mu/types/cons.rs, remove mu_append; core:/libfunctions.rs remove native function table for mu: append