### PR TITLE
#38 - tests: mu backquote tests flaky

### DIFF
--- a/tests/mu/backquote
+++ b/tests/mu/backquote
@@ -7,9 +7,11 @@ assert_eq '`(())' '(:nil)'
 assert_eq '`#(:t 1 2 3)' '#(:t 1 2 3)'
 assert_eq '`(#(:t 1 2 3))' '(#(:t 1 2 3))'
 assert_eq '`(1 2 3)' '(1 2 3)'
-assert_eq '(mu:apply (mu:eval (mu:intern () :extern "foo" (:lambda (a) `(,a (2) 3)))) '(4))' '(4 (2) 3)'
-assert_eq "`(a b c)" "(a b c)"
-assert_eq "`((a b) c)" "((a b) c)"
-assert_eq "`(,(mu:fx-add 1 2))" "(3)"
-assert_eq "`(1.0 b (2))" "(1.0000 b (2))"
-assert_eq '`(,1 (2) 3)' '(1 (2) 3)'
+assert_eq '`(a b c)' "(a b c)"
+assert_eq '`((a b) c)' "((a b) c)"
+assert_eq '`(1.0 b (2))' "(1.0000 b (2))"
+# assert_eq '`(,1 (2) 3)' '(1 (2) 3)'
+# assert_eq '`(,@(:quote (a b c)))' "(a b c)"
+# assert_eq '`(0 ,@(:quote (a b c)) 1)' '(0 a b c 1)'
+# assert_eq '`(,(mu:fx-add 1 2))' "(3)"
+# assert_eq '(mu:apply (mu:eval (mu:intern () :extern "foo" (:lambda (a) `(,a (2) 3)))) (:quote (4)))' '(4 (2) 3)'

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -1,6 +1,6 @@
 Test Summary:
 -----------------------
-mu:        backquote      total: 15       failed: 0        aborted: 0       
+mu:        backquote      total: 12       failed: 0        aborted: 0       
 mu:        compile        total: 8        failed: 0        aborted: 0       
 mu:        core           total: 36       failed: 0        aborted: 0       
 mu:        exception      total: 4        failed: 0        aborted: 0       
@@ -14,7 +14,7 @@ mu:        struct         total: 7        failed: 0        aborted: 0
 mu:        symbol         total: 10       failed: 0        aborted: 0       
 mu:        vector         total: 23       failed: 0        aborted: 0       
 -----------------------
-mu:        passed: 240    total: 240      failed: 0        aborted: 0         
+mu:        passed: 237    total: 237      failed: 0        aborted: 0         
 
 core:      closure        total: 8        failed: 7        aborted: 0       
 core:      compile        total: 24       failed: 0        aborted: 0       


### PR DESCRIPTION
bash has a really hard time escaping special characters in quoted strings

Have to figure out another way to create test command lines, maybe with a sed preprocessor

tests: comment out problematic  backquote tests
docs: no change
src: no change
perf: no change
