### PR TITLE
#109 - core: rethink compilation

### DIFF
--- a/dist/thorn.mk
+++ b/dist/thorn.mk
@@ -8,7 +8,8 @@ SRC = ../src
 CORE = \
 	core.l		\
 	closures.l	\
-        compile.l	\
+	funcall.l	\
+	compile.l	\
 	fixnums.l	\
 	read-macro.l	\
 	read.l		\

--- a/dist/thorn.sh
+++ b/dist/thorn.sh
@@ -23,6 +23,7 @@ SOURCES=""
 CORE=(\
 	core.l	     	\
 	closures.l      \
+	funcall.l       \
 	fixnums.l       \
 	read-macro.l    \
 	read.l       	\

--- a/src/core/closures.l
+++ b/src/core/closures.l
@@ -2,6 +2,10 @@
 ;;;  SPDX-License-Identifier: MIT
 
 ;;;
+;;; closures
+;;;
+
+;;;
 ;;; [*closure descriptor*] #s(:closure env nreqs rest func)
 ;;;
 ;;; env:   list of frame state structs
@@ -9,7 +13,6 @@
 ;;; rest:  rest symbol or nil
 ;;; func:  function, mu applyable
 ;;;
-;;; closure
 (mu:intern core::ns :intern "closure-property"
   (:lambda (key closure)
     (core:raise-unless core:closurep closure 'core::closure-property "is not a closure")
@@ -48,125 +51,3 @@
           (core::lambda-property :env lambda-desc)))
         (mu:cdr (core::fn-form fn))))
      (core::fn-lambda-desc fn))))
-
-;;;
-;;; core argument lists
-;;;
-(mu:intern core::ns :intern "flat-arg-list"
-    (:lambda (args)
-      (core:foldr
-       (:lambda (elt acc)
-         `(mu:cons ,elt ,acc))
-       ()
-       args)))
-
-(mu:intern core::ns :intern "lambda-arg-list"
-   (:lambda (fn args)
-      (:if (core:closurep fn)
-           ((:lambda (nreqs)
-               (:if (core::and (core::closure-property :rest fn) (core:zerop nreqs))
-                    `(mu:cons ,(core::flat-arg-list args) ())
-                    ((:lambda (reqs rest)
-                        (core::flat-arg-list `(,@reqs ,(core::flat-arg-list rest))))
-                     (core:dropr args (mu:fx-sub (mu:length args) nreqs))
-                     (core:dropl args nreqs))))
-            (core::closure-property :nreqs fn))
-           (core::flat-arg-list args))))
-
-(mu:intern core::ns :intern "quoted-lambda-arg-list"
-  (:lambda (fn args)
-    (:if (core:functionp fn)
-         args
-         (:if (core::closure-property :rest fn)
-              (:if (core::and (core:closure-property :rest fn) (core:zerop (core::closure-property :arity fn)))
-                   `(,args)
-                   `(,@(core:dropr args (mu:fx-sub (mu:length args) (core::closure-property :arity fn)))
-                     ,@(core:dropl args (core::closure-property :arity fn))))
-              args))))
-
-;;;
-;;; compiled argument lists
-;;;
-(mu:intern core::ns :intern "compile-flat-arg-list"
-  (:lambda (args env)
-    (core:foldr
-     (:lambda (elt acc)
-       (mu:cons 'mu:cons (mu:cons (core::compile elt env) `(,acc))))
-     ()
-     args)))
-
-(mu:intern core::ns :intern "compile-quoted-lambda-arg-list"
-   (:lambda (fn args env)
-     (core::quoted-lambda-arg-list
-      fn
-      (core:mapcar (:lambda (elt) (core::compile elt env)) args))))
-
-(mu:intern core::ns :intern "closure-apply"
-   (:lambda (fn args)
-    ((:lambda (env)
-        (core:mapc mu:fr-push env)
-        ((:lambda (value)
-           (core:mapc mu:fr-pop env)
-           value)
-         ((:lambda (mu-fn)
-            (mu:apply mu-fn (mu:eval (core::lambda-arg-list fn args))))
-            (core::closure-property :func fn))))
-        (core::closure-property :env fn))))
-
-;;;
-;;; compile-application
-;;;
-;;; expand macros
-;;; convert core lambdas to mu forms
-;;; compile function applications
-;;;
-(mu:intern core::ns :intern "compile-lambda-call"
-  (:lambda (form args env)
-    ((:lambda (fn)
-        (:if (core:closurep fn)
-            `(core::closure-apply ,fn ,(core::compile-flat-arg-list args env))
-            (mu:cons fn (core::compile-quoted-lambda-arg-list fn args env))))
-     (core::compile form env))))
-
-(mu:intern core::ns :intern "compile-fn-call"
-   (:lambda (fn args env)
-    (:if (core:closurep fn)
-         `(core:apply ,fn ,(core::compile-flat-arg-list args env))
-         (mu:cons fn (core::compile-quoted-lambda-arg-list fn args env)))))
-
-(mu:intern core::ns :intern "compile-macro-call"
-  (:lambda (macro-symbol args env)
-    (core::compile
-     (core:macroexpand `(macro-symbol ,@args) env)
-     env)))
-
-(mu:intern core::ns :intern "compile-symbol-call"
-  (:lambda (symbol args env)
-    (:if (core:boundp symbol)
-         ((:lambda (fn)
-            (:if (core:closurep fn)
-                 (:if (core::lambda-property :desc fn)
-                      `(core:apply ,fn ,(core::compile-flat-arg-list args env))
-                      `(,fn ,@(core::compile-quoted-lambda-arg-list fn args env)))
-                 `(mu:apply ,fn ,(core::compile-flat-arg-list args env))))
-          (core:symbol-value (core::compile symbol env)))
-         `(core:apply ,(core::compile symbol env) ,(core::compile-flat-arg-list args env)))))
-
-;;;
-;;; compile function application
-;;;
-(mu:intern core::ns :intern "compile-application"
-  (:lambda (fn args env)
-    (:if (core:functionp fn)
-         (core::compile-fn-call fn args env)
-         (:if (core:consp fn)
-              (core::compile-lambda-call fn args env)
-              (:if (mu:eq :symbol (mu:type-of fn))
-                   (:if (core:boundp fn)
-                        ((:lambda (macro-fn)
-                           (:if macro-fn
-                                (core::compile-macro-call fn args env)
-                                (core::compile-symbol-call fn args env)))
-                         (core:macro-function fn env))
-                        (core::compile-symbol-call fn args env))
-                   (core:raise fn 'compile-application "not a function designator"))))))

--- a/src/core/compile.l
+++ b/src/core/compile.l
@@ -73,26 +73,20 @@
    (:lambda (form env)
       ((:lambda (symbol value)
           (:if (mu:eq :symbol (mu:type-of symbol))
-               (mu:compile
-                `(:quote
-                  ,(core::intern
-                    symbol
-                    (mu:eval (core::compile value env)))))
+               `(:quote
+                 ,(core::intern
+                   symbol
+                   (mu:eval value)))
                (core:raise symbol 'defconst "not a symbol")))
           (mu:nth 1 form)
           (mu:nth 2 form))))
 
 (mu:intern core::ns :intern "defmacro"
    (:lambda (form env)
-      ((:lambda (symbol lambda)
-          (core:raise-unless core:listp lambda 'defmacro "not a lambda list")
-          (:if (mu:eq :symbol (mu:type-of symbol))
-               ((:lambda (macro-fn)
-                   ((:lambda (symbol)
-                       (core::core-macro-env symbol macro-fn)
-                       (mu:compile `(:quote ,symbol)))
-                    (core::intern symbol macro-fn)))
-                (core::compile-macro `(,(mu:car lambda) ,(mu:cdr lambda)) env))
+      ((:lambda (symbol lambda-form)
+          (:if (core:symbolp symbol)
+               ;; `(:quote (core::intern ,symbol (core::core-macro-env ,symbol (core::compile-macro ,lambda-form) ,env)))
+               `(:quote ,symbol)
                (core:raise symbol 'defmacro "not a symbol")))
        (mu:nth 1 form)
        (mu:nthcdr 2 form))))
@@ -164,23 +158,33 @@
 ;;; compile
 ;;;
 (mu:intern core::ns :intern "compile"
-    (:lambda (form env)
+   (:lambda (form env)
       (:if (core:consp form)
-          ((:lambda (fn args)
-             (:if (core:keywordp fn)
-                  (mu:compile form)     ;;; mu special form (:key ...)
-                  (:if (core:consp fn)  ;;; application ((...) ...), native or core
-                       (core::compile-application fn args env)
-                       ((:lambda (special)
-                          (:if special
-                               (mu:apply (mu:sy-val special) `(,form ,env))
-                               (core::compile-application fn args env)))
-                        (core::special-table fn)))))
-           (mu:car form)
-           (mu:cdr form))
-          (:if (mu:eq :symbol (mu:type-of form))
-               (core::compile-symbol form env)
-               (mu:compile form)))))
+           ((:lambda (fn args)
+               (:if (core::or (core:closurep fn) (core:functionp fn))
+                    (core::compile-fn-call fn args env)
+                    (:if (core:keywordp fn)
+                         (mu:compile form)     ; mu special form (:key ...)
+                         (:if (core:consp fn)  ; application ((...) ...), native or core
+                              (core::compile-lambda-call fn args env)
+                              (:if (core:symbolp fn) ; symbol, function symbol or special form
+                                   ((:lambda (special)
+                                       (:if special
+                                            (core::compile (mu:apply (mu:sy-val special) `(,form ,env)) env)
+                                            (:if (core:fboundp fn)
+                                                 ((:lambda (macro-fn)
+                                                     (:if macro-fn
+                                                          (core::compile-macro-call fn args env)
+                                                          (core::compile-symbol-call fn args env)))
+                                                  (core:macro-function fn env))
+                                                 (core::compile-symbol-call fn args env))))
+                                    (core::special-table fn))
+                                   (core:raise form 'core::compile "not a function designator"))))))
+            (mu:car form)
+            (mu:cdr form))
+           (:if (core:symbolp form)
+                (core::compile-symbol form env)
+                form))))
 
 (mu:intern core::ns :extern "compile"
    (:lambda (form)

--- a/src/core/funcall.l
+++ b/src/core/funcall.l
@@ -1,0 +1,109 @@
+;;;  SPDX-FileCopyrightText: Copyright 2017 James M. Putnam (putnamjm.design@gmail.com)
+;;;  SPDX-License-Identifier: MIT
+
+;;;
+;;; compile funcalls
+;;;
+
+;;;
+;;; core argument lists
+;;;
+(mu:intern core::ns :intern "flat-arg-list"
+    (:lambda (args)
+      (core:foldr
+       (:lambda (elt acc)
+         `(mu:cons ,elt ,acc))
+       ()
+       args)))
+
+(mu:intern core::ns :intern "lambda-arg-list"
+   (:lambda (fn args)
+      (:if (core:closurep fn)
+           ((:lambda (nreqs)
+               (:if (core::and (core::closure-property :rest fn) (core:zerop nreqs))
+                    `(mu:cons ,(core::flat-arg-list args) ())
+                    ((:lambda (reqs rest)
+                        (core::flat-arg-list `(,@reqs ,(core::flat-arg-list rest))))
+                     (core:dropr args (mu:fx-sub (mu:length args) nreqs))
+                     (core:dropl args nreqs))))
+            (core::closure-property :nreqs fn))
+           (core::flat-arg-list args))))
+
+(mu:intern core::ns :intern "quoted-lambda-arg-list"
+  (:lambda (fn args)
+    (:if (core:functionp fn)
+         args
+         (:if (core::closure-property :rest fn)
+              (:if (core::and (core:closure-property :rest fn) (core:zerop (core::closure-property :arity fn)))
+                   `(,args)
+                   `(,@(core:dropr args (mu:fx-sub (mu:length args) (core::closure-property :arity fn)))
+                     ,@(core:dropl args (core::closure-property :arity fn))))
+              args))))
+
+;;;
+;;; compiled argument lists
+;;;
+(mu:intern core::ns :intern "compile-flat-arg-list"
+  (:lambda (args env)
+    (core:foldr
+     (:lambda (elt acc)
+       (mu:cons 'mu:cons (mu:cons (core::compile elt env) `(,acc))))
+     ()
+     args)))
+
+(mu:intern core::ns :intern "compile-quoted-lambda-arg-list"
+   (:lambda (fn args env)
+     (core::quoted-lambda-arg-list
+      fn
+      (core:mapcar (:lambda (elt) (core::compile elt env)) args))))
+
+(mu:intern core::ns :intern "closure-apply"
+   (:lambda (fn args)
+    ((:lambda (env)
+        (core:mapc mu:fr-push env)
+        ((:lambda (value)
+           (core:mapc mu:fr-pop env)
+           value)
+         ((:lambda (mu-fn)
+            (mu:apply mu-fn (mu:eval (core::lambda-arg-list fn args))))
+            (core::closure-property :func fn))))
+        (core::closure-property :env fn))))
+
+;;;
+;;; compile-application
+;;;
+;;; expand macros
+;;; convert core lambdas to mu forms
+;;; compile function applications
+;;;
+(mu:intern core::ns :intern "compile-lambda-call"
+  (:lambda (form args env)
+    ((:lambda (fn)
+        (:if (core:closurep fn)
+            `(core::closure-apply ,fn ,(core::compile-flat-arg-list args env))
+            (mu:cons fn (core::compile-quoted-lambda-arg-list fn args env))))
+     (core::compile form env))))
+
+(mu:intern core::ns :intern "compile-fn-call"
+   (:lambda (fn args env)
+    (:if (core:closurep fn)
+         `(core:apply ,fn ,(core::compile-flat-arg-list args env))
+         (mu:cons fn (core::compile-quoted-lambda-arg-list fn args env)))))
+
+(mu:intern core::ns :intern "compile-macro-call"
+  (:lambda (macro-symbol args env)
+    (core::compile
+     (core:macroexpand `(macro-symbol ,@args) env)
+     env)))
+
+(mu:intern core::ns :intern "compile-symbol-call"
+  (:lambda (symbol args env)
+    (:if (core:boundp symbol)
+         ((:lambda (fn)
+            (:if (core:closurep fn)
+                 (:if (core::lambda-property :desc fn)
+                      `(core:apply ,fn ,(core::compile-flat-arg-list args env))
+                      `(,fn ,@(core::compile-quoted-lambda-arg-list fn args env)))
+                 `(mu:apply ,fn ,(core::compile-flat-arg-list args env))))
+          (core:symbol-value (core::compile symbol env)))
+         `(core:apply ,(core::compile symbol env) ,(core::compile-flat-arg-list args env)))))

--- a/src/core/macro.l
+++ b/src/core/macro.l
@@ -135,4 +135,4 @@
         `(:lambda ,(core::lambda-property :syms lambda-desc)
                   ,@(core::compile-lambda-body lambda-desc body env))))
      (core::core-macro (mu:car form) env)
-     (mu:nth 1 form))))
+     (mu:nthcdr 1 form))))

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -23,9 +23,9 @@ core       compile        total: 24       passed: 24       failed: 0        abor
 core       core           total: 25       passed: 25       failed: 0        aborted: 0       
 core       exception      total: 11       passed: 11       failed: 0        aborted: 0       
 core       format         total: 15       passed: 15       failed: 0        aborted: 0       
-core       lambda         total: 28       passed: 28       failed: 0        aborted: 0       
+core       lambda         total: 28       passed: 17       failed: 0        aborted: 11      
 core       list           total: 78       passed: 78       failed: 0        aborted: 0       
-core       macro          total: 9        passed: 9        failed: 0        aborted: 0       
+core       macro          total: 9        passed: 6        failed: 1        aborted: 2       
 core       reader         total: 56       passed: 56       failed: 0        aborted: 0       
 core       sequence       total: 2        passed: 2        failed: 0        aborted: 0       
 core       stream         total: 22       passed: 22       failed: 0        aborted: 0       
@@ -34,5 +34,5 @@ core       symbol         total: 4        passed: 4        failed: 0        abor
 core       types          total: 6        passed: 6        failed: 0        aborted: 0       
 core       vector         total: 13       passed: 13       failed: 0        aborted: 0       
 -----------------------
-core       passed: 314    total: 320      failed: 0        aborted: 6         
+core       passed: 300    total: 320      failed: 1        aborted: 19        
 


### PR DESCRIPTION
reorganize compiler main, partition sources

docs: no change
tests: in addition to backquote brain damage, we now fail half the lambda tests and a couple of the macro tests
perf: no change
srcs: new file in core