### PR TITLE
#155 - core: remove exception warning

### DIFF
--- a/src/core/exceptions.l
+++ b/src/core/exceptions.l
@@ -61,13 +61,12 @@
   (:lambda (handler thunk)
     (mu:with-ex
      (:lambda (object condition source)
-          (core:warn condition "raise")
-          (:if (mu:eq condition :except)
-               (core:apply handler `(,object))
-               (core:apply
-                handler
-                `(,(core:make-exception condition object source "mu:raise" (core:dropl (mu::frames) 4))))))
-       (:lambda () (core:apply thunk ())))))
+        (:if (mu:eq condition :except)
+             (core:apply handler `(,object))
+             (core:apply
+              handler
+              `(,(core:make-exception condition object source "mu:raise" (core:dropl (mu::frames) 4))))))
+     (:lambda () (core:apply thunk ())))))
 
 ;;;
 ;;; exception flavors


### PR DESCRIPTION
remove warning from core:with-exception

docs: no change
tests: no change
perf: no change
srcs: remove warning in core/exceptions.l