### PR TITLE
#262 - core: rethink type checking mechanism

### DIFF
--- a/src/core/core.l
+++ b/src/core/core.l
@@ -113,10 +113,11 @@
 
 (mu:intern core "apply"
    (:lambda (fn args)
-     (core:raise-unless core:%appliablep fn 'core:apply "not a function designator")
-     (:if (core:closurep fn)
-          (core:%closure-apply fn args)
-          (mu:apply fn args))))
+     (:if (core:%appliablep fn)
+          (:if (core:closurep fn)
+               (core:%closure-apply fn args)
+               (mu:apply fn args))
+          (core:raise fn 'core:apply "not a function designator"))))
 
 ;;;
 ;;; fixpoint loop

--- a/src/core/fixnums.l
+++ b/src/core/fixnums.l
@@ -6,13 +6,15 @@
 ;;;
 (mu:intern core "1+"
    (:lambda (n)
-     (core:raise-unless core:fixnump n 'core:1+ "not a fixnum")
-     (mu:fx-add n 1)))
+     (:if (core:fixnump n)
+          (mu:fx-add n 1)
+          (core:raise n 'core:1+ "not a fixnum"))))
 
 (mu:intern core "1-"
    (:lambda (n)
-     (core:raise-unless core:fixnump n 'core:1- "not a fixnum")
-     (mu:fx-sub n 1)))
+     (:if (core:fixnump n)
+          (mu:fx-sub n 1)
+          (core:raise n 'core:1- "not a fixnum"))))
 
 (mu:intern core "truncate"
    (:lambda (n m)

--- a/src/core/lambda.l
+++ b/src/core/lambda.l
@@ -46,7 +46,6 @@
 ;;;
 (mu:intern core "%core-lambda"
    (:lambda (lambda env)
-      ;; (core:raise-unless core:listp lambda 'core::core-lambda "not a lambda list")
       (:if (core:findl (:lambda (el) (core:null (mu:eq :symbol (mu:type-of el)))) lambda)
          (core:raise lambda 'core:%core-lambda "list syntax")
          ((:lambda (desc)

--- a/src/core/streams.l
+++ b/src/core/streams.l
@@ -19,7 +19,11 @@
          mu:std-out
          (:if (core:streamp designator)
               designator
-              (core:raise-unless core:streamp designator 'core:%write-stream-designator "not a stream")))))
+              (core:raise-unless
+               core:streamp
+               designator
+               'core:%write-stream-designator
+               "not a stream")))))
 
 (mu:intern core "%read-stream-designator"
   (:lambda (designator)
@@ -29,7 +33,11 @@
               mu:std-in
               (:if (core:streamp designator)
                    designator
-                   (core:raise-unless core:streamp designator 'core:%read-stream-designator "not a stream"))))))
+                   (core:raise-unless
+                    core:streamp
+                    designator
+                    'core:%read-stream-designator
+                    "not a stream"))))))
 
 ;;;
 ;;; constructors
@@ -56,7 +64,7 @@
 
 (mu:intern core "close"
   (:lambda (stream)
-    (core:raise-unless core:streamp stream 'core:close "not a string")
+    (core:raise-unless core:streamp stream 'core:close "not a stream")
     (mu:close stream)))
 
 ;;;

--- a/src/core/types.l
+++ b/src/core/types.l
@@ -70,14 +70,21 @@
                (core:%mapc
                 (:lambda (property-value)
                    ((:lambda (property-def)
-                       (core:raise-when core:null property-def 'core:%make-core-type "undefined property"))
+                             (core:raise-when
+                              core:null
+                              property-def
+                              'core:%make-core-type
+                              "undefined property"))
                     (core:findl
                      (:lambda (property-def)
                         (:if (mu:eq (mu:car property-value) (mu:car property-def))
                              ((:lambda (type value)
                                  (:if (core:%core-type-predicate type value)
                                       property-def
-                                      (core:raise property-value 'core:%make-core-type `(,type ,value "property type botch"))))
+                                      (core:raise
+                                       property-value
+                                       'core:%make-core-type
+                                       `(,type ,value "property type botch"))))
                               (mu:cdr property-def)
                               (mu:cdr property-value))
                              ()))


### PR DESCRIPTION
Eliminate a few more blind calls to core:raise- functions

docs: no change
tests: no change
srcs: functions in core.l, fixnums.l (1+ and 1-), lambda.l streams.l, and types.l got reworked
perf:  5-50% saving in a couple of dozen tests. gains seem to be biggest in reader tests.  negligable change in timing.