### PR TITLE
#625 - core: bit vector implementation

### DIFF
--- a/src/core/read-macro.l
+++ b/src/core/read-macro.l
@@ -71,13 +71,15 @@
    (:lambda (ch stream)
      (mu:fix
        (:lambda (loop)
-         (:if (mu:eq :vector (mu:type-of loop))
+         (:if (core:vectorp loop)
               loop
               ((:lambda (byte-descriptor)
                  (:if (core:consp byte-descriptor)
                       ((:lambda (length byte)
-                         ;;; (core:warn (mu:fx-add length (mu:fx-mul 8 (mu:length loop))) "done: length in bits")
-                         (mu:make-sv :byte (core:reverse (mu:cons byte loop))))
+                         (core:%make-vector
+                          (mu:make-sv :byte (core:reverse (mu:cons byte loop)))
+                          ()
+                          (mu:cons (mu:fx-add length (mu:fx-mul 8 (mu:length loop))) ())))
                        (mu:car byte-descriptor)
                        (mu:cdr byte-descriptor))
                        (mu:cons byte-descriptor loop)))

--- a/src/core/vector.l
+++ b/src/core/vector.l
@@ -58,7 +58,7 @@
 ;;;
 (mu:intern :core "%vector-write"
    (:lambda (vector escape stream)
-      (:if (core:typep vector :vector)
+       (:if (core:typep vector :vector)
            (mu:write vector escape stream)
            ((:lambda (length)
                (core:format stream "#(" ())


### PR DESCRIPTION
reader now creates a vector ctype

docs: no change
tests: no change
perf: no change
srcs: connect reader sharp macro to %make-vector